### PR TITLE
Properly refresh Permission Groups

### DIFF
--- a/NWAPIPermissionSystem/PermissionHandler.cs
+++ b/NWAPIPermissionSystem/PermissionHandler.cs
@@ -42,6 +42,8 @@ namespace NWAPIPermissionSystem
             }
             
             Plugin.Singleton.Handler.LoadConfig(Plugin.Singleton, nameof(Plugin.PermissionsConfig));
+            
+            PermissionGroups.Clear();
 
             foreach (var group in Plugin.Singleton.PermissionsConfig.Groups)
             {


### PR DESCRIPTION
fixes calling `NWAPIPermissionSystem.PermissionHandler.ReloadPermissions()` causing a `System.ArgumentException` and ensures changes are properly reflected