### PR TITLE
"someplugin.somefeature.*" doesn't work

### DIFF
--- a/NWAPIPermissionSystem/PermissionHandler.cs
+++ b/NWAPIPermissionSystem/PermissionHandler.cs
@@ -162,12 +162,15 @@ namespace NWAPIPermissionSystem
             if (group.CombinedPermissions.Contains(".*"))
                 return true;
             string[] sp = permission.Split('.');
-            if (sp.Length != 1)
-                if (group.CombinedPermissions.Contains(sp[0] + ".*"))
-                    return true;
             if (sp.Length == 1)
                 if (group.CombinedPermissions.Any(perm => perm.StartsWith(sp[0])))
                     return true;
+                if (sp.Length == 2)
+                    if (group.CombinedPermissions.Contains(sp[0] + ".*"))
+                        return true;
+                if (sp.Length == 3)
+                    if (group.CombinedPermissions.Contains(sp[0] + "." + sp[1] + ".*"))
+                        return true;
             foreach(var perm in group.CombinedPermissions)
                 if (perm == permission)
                     return true;

--- a/NWAPIPermissionSystem/PermissionHandler.cs
+++ b/NWAPIPermissionSystem/PermissionHandler.cs
@@ -165,12 +165,12 @@ namespace NWAPIPermissionSystem
             if (sp.Length == 1)
                 if (group.CombinedPermissions.Any(perm => perm.StartsWith(sp[0])))
                     return true;
-                if (sp.Length == 2)
-                    if (group.CombinedPermissions.Contains(sp[0] + ".*"))
-                        return true;
-                if (sp.Length == 3)
-                    if (group.CombinedPermissions.Contains(sp[0] + "." + sp[1] + ".*"))
-                        return true;
+            if (sp.Length == 2)
+                if (group.CombinedPermissions.Contains(sp[0] + ".*"))
+                    return true;
+            if (sp.Length == 3)
+                if (group.CombinedPermissions.Contains(sp[0] + "." + sp[1] + ".*"))
+                    return true;
             foreach(var perm in group.CombinedPermissions)
                 if (perm == permission)
                     return true;


### PR DESCRIPTION
If I have "someplugin.somefeature.*" permission, I still can't use a command that requires e.g. "someplugin.somefeature.feature1" permission. I receive response that I don't have permission to use that command.